### PR TITLE
fix: production build

### DIFF
--- a/.changeset/khaki-geese-listen.md
+++ b/.changeset/khaki-geese-listen.md
@@ -1,0 +1,5 @@
+---
+"@react-flight/webpack-plugin": patch
+---
+
+Fix production build

--- a/examples/fixture-flight/data-server.js
+++ b/examples/fixture-flight/data-server.js
@@ -11,13 +11,13 @@ const {
 	ReactServerDOMWebpackServer,
 	React,
 	getServerAction,
-} = require("./dist/server-entry");
+} = require("./dist/server/server-entry");
 
 const clientModulesManifest = JSON.parse(
-	fs.readFileSync(path.resolve(__dirname, `./dist/client-modules.json`), "utf8")
+	fs.readFileSync(path.resolve(__dirname, `./dist/client/client-modules.json`), "utf8")
 );
 const serverActionsManifest = JSON.parse(
-	fs.readFileSync(path.resolve(__dirname, `./dist/server-actions.json`), "utf8")
+	fs.readFileSync(path.resolve(__dirname, `./dist/server/server-actions.json`), "utf8")
 );
 
 const app = express();

--- a/examples/fixture-flight/ssr-server.js
+++ b/examples/fixture-flight/ssr-server.js
@@ -3,17 +3,17 @@ const fs = require("node:fs");
 const http = require("node:http");
 const express = require("express");
 const compress = require("compression");
-const { ReactServerDOMWebpackClient, ReactDOMServer } = require("./dist/server-entry");
+const { ReactServerDOMWebpackClient, ReactDOMServer } = require("./dist/server/server-entry");
 
 const clientModulesSSRManifest = JSON.parse(
-	fs.readFileSync(path.resolve(__dirname, `./dist/client-modules-ssr.json`), "utf8")
+	fs.readFileSync(path.resolve(__dirname, `./dist/client/client-modules-ssr.json`), "utf8")
 );
 
 const app = express();
 
 app.use(compress());
 
-app.use(express.static(path.resolve(__dirname, "./dist")));
+app.use(express.static(path.join(__dirname, "dist", "client")));
 
 function request(options, body) {
 	return new Promise((resolve, reject) => {
@@ -67,7 +67,7 @@ app.all("/", async function (req, res) {
 			// Render it into HTML by resolving the client components
 			res.set("Content-type", "text/html");
 			const { pipe } = ReactDOMServer.renderToPipeableStream(root, {
-				bootstrapScripts: ["client-entry.js"],
+				bootstrapScripts: ["client-entry-8a6ea1e0bd297105e030.js"],
 			});
 			pipe(res);
 		} catch (e) {

--- a/examples/fixture-flight/webpack.config.js
+++ b/examples/fixture-flight/webpack.config.js
@@ -43,11 +43,23 @@ module.exports = [
 				},
 			},
 		},
-		mode: "development",
+		output: {
+			path: path.join(__dirname, "dist", "server"),
+		},
+		mode: "production",
 		target: "node",
 		devtool: false,
 		module: {
-			rules: [jsRule, ...reactServerRules({ test: /\.jsx?$/ })],
+			rules: [
+				jsRule,
+				{
+					test: /\.jsx?$/,
+					issuerLayer: "server",
+					resolve: {
+						conditionNames: ["react-server", "..."],
+					},
+				},
+			],
 		},
 		plugins: [new ReactFlightServerWebpackPlugin()],
 		externals: {
@@ -65,7 +77,11 @@ module.exports = [
 		entry: {
 			["client-entry"]: "./src/client-entry.js",
 		},
-		mode: "development",
+		output: {
+			filename: "[name]-[contenthash].js",
+			path: path.join(__dirname, "dist", "client"),
+		},
+		mode: "production",
 		target: "web",
 		devtool: false,
 		module: {

--- a/packages/webpack-plugin/src/index.js
+++ b/packages/webpack-plugin/src/index.js
@@ -24,7 +24,7 @@ class ReactFlightServerWebpackPlugin {
 			ReactFlightServerWebpackPlugin.name,
 			async (compilation) => {
 				const addEntry = (resources, layer) => {
-					// use dynamic import to ensure not to be tree shaken or concatenated
+					// use dynamic import to ensure not to be tree-shaken or concatenated
 					const entrySource = resources
 						.map((resource) => `import(/* webpackMode: "eager" */ ${JSON.stringify(resource)});`)
 						.join("");

--- a/packages/webpack-plugin/src/runtime/server.js
+++ b/packages/webpack-plugin/src/runtime/server.js
@@ -194,7 +194,6 @@ export function createServerAction(resourcePath, fn) {
 
 // TODO: use loadServerReference from react-server-dom-webpack?
 export function getServerAction(serverReference, serverActionsManifest) {
-	const [, name] = serverReference.split("#");
 	const moduleData = serverActionsManifest[serverReference];
-	return __webpack_require__(moduleData.id)[name];
+	return __webpack_require__(moduleData.id)[moduleData.name];
 }

--- a/packages/webpack-plugin/src/shared.js
+++ b/packages/webpack-plugin/src/shared.js
@@ -1,0 +1,22 @@
+/** flight types */
+exports.SERVER_COMPONENT = Symbol("flight type: server components");
+exports.SERVER_ACTION_FROM_SERVER = Symbol("flight type: server actions from server");
+exports.SERVER_ACTION_FROM_CLIENT = Symbol("flight type: server actions from client");
+
+/** compile phase */
+exports.CSR_PHASE = Symbol("compile phase: client compile - csr client components");
+exports.SERVER_PHASE = Symbol(
+	"compile phase: server compile - server components, server actions from server"
+);
+exports.SSR_PHASE = Symbol("compile phase: server compile - ssr client components");
+exports.SERVER_FROM_CLIENT_PHASE = Symbol(
+	"compile phase: server compile - server actions from client"
+);
+
+/** shared state for server plugin and client plugin */
+exports.state = {
+	clientModuleReferences: new Map(),
+	serverActionFromServerResources: new Set(),
+	serverActionFromClientResources: new Set(),
+	currentLayer: exports.SERVER_PHASE,
+};


### PR DESCRIPTION
- remove actionLayer
  - server components, from server server actions, and from client server actions all use serverLayer
  - three layer: server (for SCs and SAs, in server compile), client (for ssr, in server compile), none (for csr, in client compile)
  - four phase: 1. server, 2. ssr, 3. from client server, 4. csr
- fix production build
  - ensure SCs and SAs not to be tree-shaken or concatenated
  - make contenthash stable